### PR TITLE
Meson build files for 1.79

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,87 @@
+project('imgui', 'cpp',
+    version: '1.79',
+    license: 'MIT',
+)
+
+# backend implementations currently in examples dir
+# however this changes with the next release
+include_dirs = include_directories('.', 'examples')
+sources = ['imgui_demo.cpp', 'imgui_draw.cpp', 'imgui_widgets.cpp', 'imgui.cpp']
+
+cpp = meson.get_compiler('cpp')
+dependencies = []
+
+# renderer backends
+dx9_dep = cpp.find_library('d3d9', required: get_option('dx9'))
+if dx9_dep.found()
+    sources += 'examples/imgui_impl_dx9.cpp'
+    dependencies += dx9_dep
+endif
+dx10_dep = cpp.find_library('d3d10', required: get_option('dx10'))
+if dx10_dep.found()
+    sources += 'examples/imgui_impl_dx10.cpp'
+    dependencies += dx10_dep
+endif
+dx11_dep = cpp.find_library('d3d11', required: get_option('dx11'))
+if dx11_dep.found()
+    sources += 'examples/imgui_impl_dx11.cpp'
+    dependencies += dx11_dep
+endif
+dx12_dep = cpp.find_library('d3d12', required: get_option('dx12'))
+if dx12_dep.found()
+    sources += 'examples/imgui_impl_dx12.cpp'
+    dependencies += dx12_dep
+endif
+metal_dep = cpp.find_library('metal', required: get_option('metal'))
+if get_option('metal').enabled()
+    sources += 'examples/imgui_impl_metal.mm'
+    dependencies += metal_dep
+endif
+glew_dep = dependency('glew', required: get_option('opengl'))
+if glew_dep.found()
+    sources += 'examples/imgui_impl_opengl3.cpp'
+    dependencies += glew_dep
+endif
+vulkan_dep = dependency('vulkan', required: get_option('vulkan'))
+if vulkan_dep.found()
+    sources += 'examples/imgui_impl_vulkan.cpp'
+    dependencies += vulkan_dep
+endif
+
+# platform backends
+glfw_dep = dependency('glfw3', required: get_option('glfw'))
+if glfw_dep.found()
+    sources += 'examples/imgui_impl_glfw.cpp'
+    dependencies += glfw_dep
+endif
+sdl2_dep = dependency('sdl2', required: get_option('sdl2'))
+if sdl2_dep.found()
+    sources += 'examples/imgui_impl_sdl.cpp'
+    dependencies += sdl2_dep
+endif
+if get_option('osx').enabled() or (get_option('osx').auto() and target_machine.system() == 'darwin')
+    sources += 'examples/imgui_impl_osx.mm'
+endif
+if get_option('win').enabled() or (get_option('win').auto() and target_machine.system() == 'windows')
+    sources += 'examples/imgui_impl_win32.cpp'
+endif
+
+# frameworks
+allegro5_dep = dependency('allegro5', required: get_option('allegro5'))
+if allegro5_dep.found()
+    sources += 'examples/imgui_impl_allegro5.cpp'
+    dependencies += allegro5_dep
+endif
+marmalade_dep = cpp.find_library('marmalade', required: get_option('marmalade'))
+if marmalade_dep.found()
+    sources += 'examples/imgui_impl_marmalade.cpp'
+    dependencies += marmalade_dep
+endif
+
+imgui = library('imgui',
+    sources,
+    dependencies: dependencies,
+    include_directories: include_dirs,
+)
+
+imgui_dep = declare_dependency(include_directories: include_dirs, link_with: imgui)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,18 @@
+# renderer backends
+option('dx9', type : 'feature', value : 'auto')
+option('dx10', type : 'feature', value : 'auto')
+option('dx11', type : 'feature', value : 'auto')
+option('dx12', type : 'feature', value : 'auto')
+option('metal', type : 'feature', value : 'auto')
+option('opengl', type : 'feature', value : 'auto')
+option('vulkan', type : 'feature', value : 'auto')
+
+# platform backends
+option('glfw', type : 'feature', value : 'auto')
+option('sdl2', type : 'feature', value : 'auto')
+option('osx', type : 'feature', value : 'auto')
+option('win', type : 'feature', value : 'auto')
+
+# frameworks (renderer + platform)
+option('marmalade', type : 'feature', value : 'auto')
+option('allegro5', type : 'feature', value : 'auto')

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = imgui-1.79
+
+source_url = https://github.com/ocornut/imgui/archive/v1.79.tar.gz
+source_filename = imgui-1.79.tar.gz
+source_hash = f1908501f6dc6db8a4d572c29259847f6f882684b10488d3a8d2da31744cd0a4


### PR DESCRIPTION
Closes #7.

First note: with >1.79 the `examples` folder will not include the backend implementations anymore, they will be in the `backends` folder instead.

Second note, regarding #7. I switched from features to booleans, as I don't think that the library should depend on libraries just because they happen to be installed on the system. If one wants a specific implementation, it should be enabled by hand. Kinda important for reproducibility as well, as I want to use this in project that will end up in a Debian package eventually.

Third note, regarding OpenGL. I removed the legacy `opengl2` option, as one can also use OpenGL 2.x with the `opengl3` implementation as well. Also, currently we only have one OpenGL loader, namely `glew`. However, as we can see [here](https://github.com/ocornut/imgui/blob/e5cb04b132cba94f902beb6186cb58b864777012/examples/imgui_impl_opengl3.h#L57-L85), there are much more options. Since `glew` is the preferred option and I don't actually need any of those, I don't really care about implementing the others.

/cc @st4ll1 @XPXPv2 @TommyXR