### PR TITLE
Meson build files for 1.80

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,85 @@
+project('imgui', 'cpp',
+    version: '1.80',
+    license: 'MIT',
+)
+
+include_dirs = include_directories('.', 'backends')
+sources = ['imgui_demo.cpp', 'imgui_draw.cpp', 'imgui_tables.cpp', 'imgui_widgets.cpp', 'imgui.cpp']
+
+cpp = meson.get_compiler('cpp')
+dependencies = []
+
+# renderer backends
+dx9_dep = cpp.find_library('d3d9', required: get_option('dx9'))
+if dx9_dep.found()
+    sources += 'backends/imgui_impl_dx9.cpp'
+    dependencies += dx9_dep
+endif
+dx10_dep = cpp.find_library('d3d10', required: get_option('dx10'))
+if dx10_dep.found()
+    sources += 'backends/imgui_impl_dx10.cpp'
+    dependencies += dx10_dep
+endif
+dx11_dep = cpp.find_library('d3d11', required: get_option('dx11'))
+if dx11_dep.found()
+    sources += 'backends/imgui_impl_dx11.cpp'
+    dependencies += dx11_dep
+endif
+dx12_dep = cpp.find_library('d3d12', required: get_option('dx12'))
+if dx12_dep.found()
+    sources += 'backends/imgui_impl_dx12.cpp'
+    dependencies += dx12_dep
+endif
+metal_dep = cpp.find_library('metal', required: get_option('metal'))
+if get_option('metal').enabled()
+    sources += 'backends/imgui_impl_metal.mm'
+    dependencies += metal_dep
+endif
+glew_dep = dependency('glew', required: get_option('opengl'))
+if glew_dep.found()
+    sources += 'backends/imgui_impl_opengl3.cpp'
+    dependencies += glew_dep
+endif
+vulkan_dep = dependency('vulkan', required: get_option('vulkan'))
+if vulkan_dep.found()
+    sources += 'backends/imgui_impl_vulkan.cpp'
+    dependencies += vulkan_dep
+endif
+
+# platform backends
+glfw_dep = dependency('glfw3', required: get_option('glfw'))
+if glfw_dep.found()
+    sources += 'backends/imgui_impl_glfw.cpp'
+    dependencies += glfw_dep
+endif
+sdl2_dep = dependency('sdl2', required: get_option('sdl2'))
+if sdl2_dep.found()
+    sources += 'backends/imgui_impl_sdl.cpp'
+    dependencies += sdl2_dep
+endif
+if get_option('osx').enabled() or (get_option('osx').auto() and target_machine.system() == 'darwin')
+    sources += 'backends/imgui_impl_osx.mm'
+endif
+if get_option('win').enabled() or (get_option('win').auto() and target_machine.system() == 'windows')
+    sources += 'backends/imgui_impl_win32.cpp'
+endif
+
+# frameworks
+allegro5_dep = dependency('allegro5', required: get_option('allegro5'))
+if allegro5_dep.found()
+    sources += 'backends/imgui_impl_allegro5.cpp'
+    dependencies += allegro5_dep
+endif
+marmalade_dep = cpp.find_library('marmalade', required: get_option('marmalade'))
+if marmalade_dep.found()
+    sources += 'backends/imgui_impl_marmalade.cpp'
+    dependencies += marmalade_dep
+endif
+
+imgui = library('imgui',
+    sources,
+    dependencies: dependencies,
+    include_directories: include_dirs,
+)
+
+imgui_dep = declare_dependency(include_directories: include_dirs, link_with: imgui)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,18 @@
+# renderer backends
+option('dx9', type : 'feature', value : 'auto')
+option('dx10', type : 'feature', value : 'auto')
+option('dx11', type : 'feature', value : 'auto')
+option('dx12', type : 'feature', value : 'auto')
+option('metal', type : 'feature', value : 'auto')
+option('opengl', type : 'feature', value : 'auto')
+option('vulkan', type : 'feature', value : 'auto')
+
+# platform backends
+option('glfw', type : 'feature', value : 'auto')
+option('sdl2', type : 'feature', value : 'auto')
+option('osx', type : 'feature', value : 'auto')
+option('win', type : 'feature', value : 'auto')
+
+# frameworks (renderer + platform)
+option('marmalade', type : 'feature', value : 'auto')
+option('allegro5', type : 'feature', value : 'auto')

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = imgui-1.80
+
+source_url = https://github.com/ocornut/imgui/archive/v1.80.tar.gz
+source_filename = imgui-1.80.tar.gz
+source_hash = d7e4e1c7233409018437a646680316040e6977b9a635c02da93d172baad94ce9
+
+[provide]
+imgui = imgui_dep


### PR DESCRIPTION
Basically the same as for 1.79, just with one new source files (`imgui_tables.cpp`) and the renamed folder for the backends.

/cc @eli-schwartz